### PR TITLE
Use inputPath for Broccoli 2 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = {
     // Make sure we only do this stuff if prember is enabled
     if (premberOptions && (premberOptions.enabled || (this.app.env === 'production' || process.env.PREMBER))) {
       const eswPremberOptions = this.app.options['esw-prember'];
-      const configFile = new Config([appTree], eswPremberOptions);
+      const configFile = new Config(appTree, {env: this.app.env, ...eswPremberOptions});
 
       return mergeTrees([swTree, configFile]);
     }

--- a/lib/config.js
+++ b/lib/config.js
@@ -2,13 +2,12 @@
 
 const Plugin = require('broccoli-plugin');
 const fs = require('fs');
-const glob = require('glob');
 const path = require('path');
 const revHash = require('rev-hash');
 
 module.exports = class Config extends Plugin {
-  constructor(inputNodes, options) {
-    super(inputNodes, {
+  constructor(inputNode, options) {
+    super([inputNode], {
       name: options && options.name,
       annotation: options && options.annotation
     });
@@ -16,16 +15,38 @@ module.exports = class Config extends Plugin {
     this.options = options;
   }
 
+  filterFiles(filterFile, root, directory) {
+    const path = directory ? `${root}/${directory}` : root;
+    const files = fs.readdirSync(path);
+    let results = [];
+
+    for (const file of files) {
+      const relPath = directory ? `${directory}/${file}` : file;
+      const fullPath = `${root}/${relPath}`;
+      const stat = fs.statSync(fullPath);
+
+      if(stat.isFile() && file === filterFile) {
+        results.push(relPath);
+      } else if (stat.isDirectory()) {
+        results = results.concat(this.filterFiles(filterFile, root, relPath));
+      }
+    }
+
+    return results;
+  }
+
   build() {
     let options = this.options;
     let version = options.version || '1';
 
+    const root = this.inputPaths[0];
     const ext = 'index.html';
-    const htmlPages = glob.sync('tmp/prember-output*/**/' + ext);
-    const cacheMap = htmlPages.reduce((out, filePath) => {
+    const htmlFiles = this.filterFiles(ext, root, null);
+
+    const cacheMap = htmlFiles.reduce((out, file) => {
+      const filePath = `${root}/${file}`;
       const buffer = fs.readFileSync(filePath);
-      const shortFilePath = filePath.split('.tmp')[1];
-      let url = shortFilePath.substring(0, shortFilePath.length - ext.length);
+      let url = file.substring(0, file.length - ext.length);
       if (!url.startsWith('/')) {
         url = '/' + url;
       }


### PR DESCRIPTION
This PR switches to using `this.inputPaths[0]` which is actually the output of `prember` due to https://github.com/oligriffiths/ember-service-worker-prember/blob/cc81f807263af641711e44b245045aba2e78f33a/package.json#L32

I've verified the output is the same by console logging `module`:

```
export const ENVIRONMENT = 'production';
export const HTML_MAPPING = {"/blog/ad-hoc-relationships-with-ember-data/":"esw-prember-65-469a7734c4","/blog/aiming-for-targets-with-ember/":"esw-prember-65-1fc2de5766","/blog/author/rwwagner90/":"esw-prember-65-19f0c9d4f2","/blog/ember-3-1-testing-and-optional-features/":"esw-prember-65-94adac5a81","/blog/ember-data-belongs-to-find-or-create/":"esw-prember-65-978d025f18","/blog/ember-data-passing-query-params-to-save/":"esw-prember-65-7baac02d39","/blog/ember-in-repo-addons/":"esw-prember-65-b8a93a0be5","/blog/ember-inspector-the-journey-so-far/":"esw-prember-65-f4b53fdbcf","/blog/ember-meta-tags-seo-social/":"esw-prember-65-a01cad07df","/blog/ember-without-jquery/":"esw-prember-65-856b330b33","/blog/forcing-trailing-slashes-for-routes/":"esw-prember-65-83e621e244","/blog/helpful-resources-for-new-ember-devs/":"esw-prember-65-5d5781d0d9","/blog/":"esw-prember-65-8e9d1409dd","/blog/offline-first-prember-and-service-workers/":"esw-prember-65-1015d573de","/blog/reloading-hasmany-relationships/":"esw-prember-65-4aa9c80633","/blog/static-blogs-with-prember-and-markdown/":"esw-prember-65-7d064709a4","/blog/testing-ember-addons-in-an-app/":"esw-prember-65-d99ed9423e","/blog/using-components-in-ember-mixin-unit-tests/":"esw-prember-65-960916283b","/contact/":"esw-prember-65-5702c1df15","/ember-consulting/":"esw-prember-65-a555c22174","/":"esw-prember-65-6d607ee471","/open-source/":"esw-prember-65-5c624d63b7"};
```

I also fixed what appeared to be a bug with the environment coming out as `undefined`